### PR TITLE
Deconstruct Bsky responses, expose error objects

### DIFF
--- a/src/AppViewLite.Web/ApiCompat/AppBskyFeed.cs
+++ b/src/AppViewLite.Web/ApiCompat/AppBskyFeed.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using AppViewLite.Models;
 using AppViewLite;
+using System.Linq;
 
 namespace AppViewLite.Web.ApiCompat
 {
@@ -20,7 +21,7 @@ namespace AppViewLite.Web.ApiCompat
             var aturi = await Program.ResolveUriAsync(uri);
             var thread = await BlueskyEnrichedApis.Instance.GetPostThreadAsync(aturi.Did!.Handler, aturi.Rkey, EnrichDeadlineToken.Create());
 
-            var focalPostIndex = thread.FindIndex(x => x.Did == aturi.Did.Handler && x.RKey == aturi.Rkey);
+            var focalPostIndex = thread.ToList().FindIndex(x => x.Did == aturi.Did.Handler && x.RKey == aturi.Rkey);
             if (focalPostIndex == -1) throw new Exception();
             var rootPost = thread[0];
 

--- a/src/AppViewLite/AppViewLite.csproj
+++ b/src/AppViewLite/AppViewLite.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FishyFlip" Version="3.2.1" />
+    <PackageReference Include="FishyFlip" Version="3.2.2" />
     <PackageReference Include="System.IO.Hashing" Version="9.0.0" />
     <PackageReference Include="Microsoft.ML.Tokenizers" Version="1.0.0" />
     <PackageReference Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="1.0.0" />

--- a/src/AppViewLite/BlueskyRelationships.cs
+++ b/src/AppViewLite/BlueskyRelationships.cs
@@ -170,7 +170,7 @@ namespace AppViewLite
         public PostId GetPostId(StrongRef subject, bool ignoreIfNotPost = false)
         {
             var uri = subject.Uri;
-            if (uri.Collection != "app.bsky.feed.post")
+            if (uri.Collection != Post.RecordType)
             {
                 if (ignoreIfNotPost) return default;
                 throw new ArgumentException("Unexpected URI type: " + uri.Collection);
@@ -595,7 +595,7 @@ namespace AppViewLite
         }
         public PostId GetPostId(ATUri uri)
         {
-            if (uri.Collection != "app.bsky.feed.post") throw new ArgumentException();
+            if (uri.Collection != Post.RecordType) throw new ArgumentException();
             return GetPostId(uri.Did!.ToString(), uri.Rkey);
         }
 


### PR DESCRIPTION
Looking through the repo, I saw places where you use `AsT0/T1` for checking the response object. These can be deconstructed so you can access the objects directly, without needing to either use `Switch/SwitchAsync` or those helpers. Deconstructing and checking the object will help you long term when you want to introduce error handling to these methods, so you can pass up the error from the PDS if it happens. Here are [some docs on it](https://drasticactions.github.io/FishyFlip/docs/result.html). 

This PR also bumps FishyFlip, and fixes the build by `ToList`ing Thread. 

I didn't add more error handling beyond the deconstruction (since how you wish to handle that is up to you). You don't need to merge this PR, but it should give ideas for ways to do error handling in the future.
