### PR TITLE
Add FishyFlip.Xrpc binding for AppBskyActor

### DIFF
--- a/src/AppViewLite.Web/AppViewLite.Web.csproj
+++ b/src/AppViewLite.Web/AppViewLite.Web.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="..\AppViewLite\AppViewLite.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="FishyFlip.Xrpc" Version="3.10.0-alpha.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/AppViewLite/AppViewLite.csproj
+++ b/src/AppViewLite/AppViewLite.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FishyFlip" Version="3.10.0-alpha.3" />
+    <PackageReference Include="FishyFlip" Version="3.10.0-alpha.5" />
     <PackageReference Include="System.IO.Hashing" Version="9.0.0" />
     <PackageReference Include="Microsoft.ML.Tokenizers" Version="1.0.0" />
     <PackageReference Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="1.0.0" />


### PR DESCRIPTION
I noticed some talk about XRPC implementations and thought I could help (I was also thinking of writing an AppView for WhtWnd, so I wanted something for me too). I pushed a new library called [FishyFlip.Xrpc](https://github.com/drasticactions/FishyFlip/tree/develop/src/FishyFlip.Xrpc) that includes bound XRPC ASP.NET MVC controllers. This can help keep track of XRPC implementation changes and keep it in sync with the lexicon.

As part of this update, I also added IParsable support for all of the underlying FishyFlip types, which should also help with parameter and model binding, since ASP.NET should automatically handle values with those types, so you don't need to handle strings and convert later.

To show what this can do as an example, I updated AppBskyActor to use the bound controller, and reused your existing implementation. For the `actor` parameters for GetProfile/GetProfiles, they were strings and assumed that the value being passed in was a did, but that's not the case. According to the [lexicon](https://github.com/bluesky-social/atproto/blob/fb283edbaf8aa3ecc7db014a40a28173ce81bc4c/lexicons/app/bsky/actor/getProfiles.json#L14), they can be identifiers (So, `ATHandle` or `ATDid`) so if someone tried to use a handle in this case, it would most likely fail. Since I have a source generator, I can give you the exact calls needed so you can focus on the implementation.

<img width="1629" alt="スクリーンショット 2025-05-08 0 29 40" src="https://github.com/user-attachments/assets/bca8ee2d-a3f3-4737-9d57-bf69097c6a38" />


